### PR TITLE
4 steps to convert angular app to angular lazy module

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "yoshi": {
     "entry": {
       "react-client": "./react/client.js",
-      "angular-client": "./angular/client.js"
+      "angular-client": "./angular/client.js",
+      "angular-manifest": "./angular/manifest.js"
     }
   }
 }

--- a/src/angular/manifest.js
+++ b/src/angular/manifest.js
@@ -1,0 +1,17 @@
+import {ModuleRegistry, AngularLazyComponent} from 'react-module-container';
+
+class NgMainApp extends AngularLazyComponent {
+  constructor(props) {
+    super(props, {
+      files: [
+        `${props.topology.staticsBaseUrl}angular-client.css`,
+        `${props.topology.staticsBaseUrl}angular-client.bundle.js`
+      ],
+      module: 'myApp',
+      component: 'main-app',
+      unloadStylesOnDestroy: true
+    });
+  }
+}
+
+ModuleRegistry.registerComponent('angular.main', () => NgMainApp);

--- a/src/index.vm
+++ b/src/index.vm
@@ -5,22 +5,18 @@
   <meta charset="utf-8">
   <title>${title}</title>
   <link rel="stylesheet" href="${clientTopology.staticsBaseUrl}react-client.css">
-  <link rel="stylesheet" href="${clientTopology.staticsBaseUrl}angular-client.css">
 </head>
 
 <body>
   <div id="react-root"></div>
 
-  <div id="angular-root" ng-app="myApp">
-    <main-app></main-app>
-  </div>
   <script>
     window.__BASEURL__ = '${basename}';
     window.__LOCALE__ = '${locale}';
     window.__STATICS_BASE_URL__ = '${clientTopology.staticsBaseUrl}';
   </script>
+  <script src="${clientTopology.staticsBaseUrl}angular-manifest.bundle.js"></script>
   <script src="${clientTopology.staticsBaseUrl}react-client.bundle.js"></script>
-  <script src="${clientTopology.staticsBaseUrl}angular-client.bundle.js"></script>
 </body>
 
 </html>

--- a/src/react/components/App/index.js
+++ b/src/react/components/App/index.js
@@ -1,13 +1,25 @@
 import React from 'react';
 import s from './App.scss';
+import {ModuleRegistry} from 'react-module-container';
 
 class App extends React.Component {
+  componentWillMount() {
+    this.setState(() => ({
+      AngularComponent: ModuleRegistry.component('angular.main')
+    }));
+  }
   render() {
+    const AngularComponent = this.state.AngularComponent;
+    const topology = {
+      staticsBaseUrl: window.__STATICS_BASE_URL__
+    };
+
     return (
       <div className={s.root}>
         <div className={s.header}>
           <h2>{'Hello React World!'}</h2>
         </div>
+        <AngularComponent topology={topology}/>
       </div>
     );
   }


### PR DESCRIPTION
## Step 1: Add `react-module-container`
Add `react-module-container` npm module as your dependency. Run
```bash
npm install --save react-module-container
```
## Step 2: Create manifest file and register your component
Create a `manifest.js` file that describe your future lazy module. It can be either [Angular](https://github.com/wix/react-module-container/blob/master/docs/ANGULAR-LAZY-COMPONENT.md) or [React](https://github.com/wix/react-module-container/blob/master/docs/REACT-LAZY-COMPONENT.md) lazy module.
```js
class NgMainApp extends AngularLazyComponent {
  constructor(props) {
    super(props, {
      files: [
        `${props.topology.staticsBaseUrl}angular-client.css`,
        `${props.topology.staticsBaseUrl}angular-client.bundle.js`
      ],
      module: 'myApp',
      component: 'main-app',
      unloadStylesOnDestroy: true
    });
  }
}

ModuleRegistry.registerComponent('angular.main', () => NgMainApp);
```

## Step 3: Load the manifest file by hosting application
Load `manifest.js` file in the `index.html` of your hosting application.
```html
<script src="<path-to-your-manifest-file>/manifest.js"></script>
```

## Step 4: Instantiate your lazy component
Instantiate your lazy component using `ModuleRegistry` and render it inside hosting application.